### PR TITLE
Missing kwarg in Molecule.geometry_opt()

### DIFF
--- a/orca_pipeline/example/tst.yaml
+++ b/orca_pipeline/example/tst.yaml
@@ -37,9 +37,9 @@ slurm_params_high_mem:
 # - 2 files: Reaction without transition state
 # - 3 files: Reaction with transition state
 coords:
-  - product.xyz     # Coordinate file for the reactant (educt) 
-  - educt.xyz   # Coordinate file for the product    
-    #  - path/to/ts.xyz        # (Optional) Coordinate file for the transition state
+  - educt.xyz     # Coordinate file for the reactant (educt) 
+  # - product.xyz   # Coordinate file for the product    
+  #  - path/to/ts.xyz        # (Optional) Coordinate file for the transition state
 
 # Additional Settings
 fast: false               # Optional boolean to toggle fast NEB calculations (e.g., for methods not starting with "xtb")

--- a/orca_pipeline/step_runner.py
+++ b/orca_pipeline/step_runner.py
@@ -461,6 +461,7 @@ class StepRunner:
                 self.slurm_params_low_mem,
                 trial=0,
                 upper_limit=MAX_TRIALS,
+                # -> dif_scf not kwarg here; should it be here?
                 dif_scf=self.target.dif_scf,
             )
         else:


### PR DESCRIPTION
When running the OPT step from the example, error occurs in line 464 of step_runner.py bc dif_scf is not kwarg for Molecule.geometry_optimization().

Should it be there?
lg